### PR TITLE
Bug 559368 - org.eclipse.swt.SWTException: Widget is disposed.

### DIFF
--- a/bundles/org.eclipse.e4.ui.css.swt/src/org/eclipse/e4/ui/css/swt/engine/AbstractCSSSWTEngineImpl.java
+++ b/bundles/org.eclipse.e4.ui.css.swt/src/org/eclipse/e4/ui/css/swt/engine/AbstractCSSSWTEngineImpl.java
@@ -113,7 +113,8 @@ public abstract class AbstractCSSSWTEngineImpl extends CSSEngineImpl {
 	 */
 	protected boolean isStylable(Widget widget) {
 		// allows widgets to be selectively excluded from styling
-		return !Boolean.TRUE.equals(widget.getData("org.eclipse.e4.ui.css.disabled")); //$NON-NLS-1$
+		return !widget.isDisposed()
+			&& !Boolean.TRUE.equals(widget.getData("org.eclipse.e4.ui.css.disabled")); //$NON-NLS-1$
 	}
 
 	@Override


### PR DESCRIPTION
This change makes AbstractCSSSWTEngineImpl.isStylable(Widget) able to handle disposed widgets by returning false instead of throwing an exception.